### PR TITLE
remove local configuration

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Thu Jun 20 17:27:24 PDT 2019
-sdk.dir=/Users/zsweigart/Library/Android/sdk


### PR DESCRIPTION
The `local.properties` file was added to `.gitignore` but accidentally got checked in. Therefore removing it, so there is no reference to a local SDK version in the example.