### PR TITLE
ANDROID: Add public_token result TextView

### DIFF
--- a/app/src/main/java/com/plaid/linksample/MainActivity.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivity.kt
@@ -24,14 +24,17 @@ class MainActivity : AppCompatActivity() {
   }
 
   private lateinit var result: TextView
+  private lateinit var tokenResult: TextView
 
   private val myPlaidResultHandler by lazy {
     PlaidLinkResultHandler(
       requestCode = LINK_REQUEST_CODE,
       onSuccess = {
-        result.text = getString(R.string.content_success, it.publicToken)
+        tokenResult.text = getString(R.string.public_token_result, it.publicToken)
+        result.text = getString(R.string.content_success)
       },
       onCancelled = {
+        tokenResult.text = ""
         result.text = getString(
           R.string.content_cancelled,
           it.institutionId,
@@ -41,6 +44,7 @@ class MainActivity : AppCompatActivity() {
         )
       },
       onExit = {
+        tokenResult.text = ""
         result.text = getString(
           R.string.content_exit,
           it.errorMessage,
@@ -54,6 +58,7 @@ class MainActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
     result = findViewById(R.id.result)
+    tokenResult = findViewById(R.id.token_result)
 
     val button = findViewById<View>(R.id.open_link)
     button.setOnClickListener {

--- a/app/src/main/java/com/plaid/linksample/MainActivityJava.java
+++ b/app/src/main/java/com/plaid/linksample/MainActivityJava.java
@@ -30,21 +30,22 @@ public class MainActivityJava extends AppCompatActivity {
 
   private static final int LINK_REQUEST_CODE = 1;
   private TextView result;
+  private TextView tokenResult;
 
   private PlaidLinkResultHandler myPlaidResultHandler = new PlaidLinkResultHandler(
       LINK_REQUEST_CODE,
       linkConnection -> {
         LinkConnection.LinkConnectionMetadata metadata = linkConnection.getLinkConnectionMetadata();
         result.setText(getString(
-            R.string.content_success,
-            linkConnection.getPublicToken(),
-            metadata.getAccounts().get(0).getAccountId(),
-            metadata.getAccounts().get(0).getAccountName(),
-            metadata.getInstitutionId(),
-            metadata.getInstitutionName()));
+            R.string.content_success));
+        tokenResult.setText(getString(
+            R.string.public_token_result,
+            linkConnection.getPublicToken()));
         return Unit.INSTANCE;
       },
       linkCancellation -> {
+        tokenResult.setText("");
+
         result.setText(getString(
             R.string.content_cancelled,
             linkCancellation.getInstitutionId(),
@@ -54,6 +55,7 @@ public class MainActivityJava extends AppCompatActivity {
         return Unit.INSTANCE;
       },
       plaidApiError -> {
+        tokenResult.setText("");
         result.setText(getString(
             R.string.content_exit,
             plaidApiError.getDisplayMessage(),
@@ -71,6 +73,7 @@ public class MainActivityJava extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
     result = findViewById(R.id.result);
+    tokenResult = findViewById(R.id.token_result);
 
     View button = findViewById(R.id.open_link);
     button.setOnClickListener(view -> {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,14 +11,22 @@
   tools:context=".MainActivity">
 
   <TextView
+    android:id="@+id/token_result"
+    style="@style/PlaidText.H4.Semibold"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="start|center"
+    tools:text="public_token:\npublic-sandbox-12341234" />
+
+  <TextView
     android:id="@+id/result"
     style="@style/PlaidText.B1.Regular"
     android:layout_width="match_parent"
     android:layout_height="0dp"
     android:layout_weight="1"
+    android:autoLink="all"
     android:gravity="start|center"
-    android:text="@string/landing_text"
-    android:autoLink="all"/>
+    android:text="@string/landing_text" />
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/open_link"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2020 Plaid Technologies, Inc. <support@plaid.com>
   -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,15 +6,15 @@
   <string name="app_name">Link demo</string>
   <string name="title_activity_main">Link demo</string>
   <string name="title_activity_main_java">Link demo (java)</string>
+  <string name="public_token_result">public_token:\n%s</string>
   <string name="content_success">
     You did it! See, that wasn’t so hard :)
 
     \n\nThe next step is adding the Link Android SDK to your app.
 
-    \n\n1) This is your public token: <b>%1$s</b>
-    \n2) Send this key to your server to exchange it for an access token and get access to your data
-    \n3) Visit <a href="http://plaid.com/docs/link/android">http://plaid.com/docs/link/android</a> for more information on how to integrate
-    \n4) Ready for the big leagues? Unlock production access by visiting <a href="http://plaid.com/contact">http://plaid.com/contact</a></string>
+    \n1) Send this public token to your server to exchange it for an access token and get access to your data
+    \n2) Visit <a href="http://plaid.com/docs/link/android">http://plaid.com/docs/link/android</a> for more information on how to integrate
+    \n3) Ready for the big leagues? Unlock production access by visiting <a href="http://plaid.com/contact">http://plaid.com/contact</a></string>
   <string name="content_cancelled">Institution Id:\n%1$s\n\n Institution Name:\n%2$s\n\n Link Session Id:\n%3$s\n\n Status:\n%4$s</string>
   <string name="content_exit">
     Uh-oh! It seems something went wrong:\n\"%1$s\"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
 
     \n\nThe next step is adding the Link Android SDK to your app.
 
-    \n1) Send this public token to your server to exchange it for an access token and get access to your data
+    \n1) Send the public token shown above to your server to exchange it for an access token and get access to your data
     \n2) Visit <a href="http://plaid.com/docs/link/android">http://plaid.com/docs/link/android</a> for more information on how to integrate
     \n3) Ready for the big leagues? Unlock production access by visiting <a href="http://plaid.com/contact">http://plaid.com/contact</a></string>
   <string name="content_cancelled">Institution Id:\n%1$s\n\n Institution Name:\n%2$s\n\n Link Session Id:\n%3$s\n\n Status:\n%4$s</string>


### PR DESCRIPTION
Since we're autoLinking, there's some odd behavior when we return the public_token in the `result` text. Let's emphasize and clarify the public token by keeping it in its own TextView.

Before:
 ![adbscreen](https://user-images.githubusercontent.com/863461/84072631-57151c80-a984-11ea-9b56-5e7f6ef7421a.png)
After: 
![adbscreen](https://user-images.githubusercontent.com/863461/84072749-8cba0580-a984-11ea-9c9a-9e6de24ab89c.png)
