### PR TITLE
Update readme and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ To run the sample app, you'll need a Plaid account. You can create one on [our w
 3. Enter the sample app package name: `com.plaid.linksample`
 4. Click "Save Changes", you may be prompted to re-enter your password
 
-## 2. Add your public key to the sample
+## 2. Generate a link_token and add it to the sample app
 1. Clone the sample repository
-2. Copy your public key from your [Plaid Dashboard][plaid-dashboard-keys] keys page
-3. Paste your public key in [`app/src/main/res/values/donottranslate.xml`][public-key]
+2. Curl [/link/token/create](https://plaid.com/docs/#create-link-token) to create a new link_token
+3. Copy and paste the link_token in [app/src/main/res/values/donottranslate.xml][link-token]
 
 ```xml
 <resources>
-    <string name="plaid_public_key">TODO ADD YOUR KEY HERE</string>
+    <string name="plaid_public_key">TODO ADD YOUR LINK TOKEN HERE</string>
 </resources>
 ```
 
@@ -32,7 +32,7 @@ To run the sample app, you'll need a Plaid account. You can create one on [our w
 1. 🚀
 
 # Features
-- How to integrate the Plaid Link sdk: `build.gradle` files, `public_key` configuration, `Plaid` initialization
+- How to integrate the Plaid Link sdk: `build.gradle` files, `link_token` configuration, `Plaid` initialization
 - Kotlin and Java sample Activity that show how to start Link and receive a result
 - Use of `PlaidLinkResultHandler` for easy handling of Link results
 - _Optional_ use of `LinkEventListener` to get events from Link
@@ -82,5 +82,5 @@ SOFTWARE.
 [plaid-signup]: https://dashboard.plaid.com/signup?email=
 [plaid-dashboard-api]: https://dashboard.plaid.com/team/api
 [plaid-dashboard-keys]: https://dashboard.plaid.com/team/keys
-[public-key]: https://github.com/plaid/plaid-link-android/blob/update-readme/app/src/main/res/values/donottranslate.xml
+[link-token]: https://github.com/plaid/plaid-link-android/blob/update-readme/app/src/main/res/values/donottranslate.xml
 [changelog]: https://github.com/plaid/plaid-link-android/releases

--- a/README.md
+++ b/README.md
@@ -20,13 +20,7 @@ To run the sample app, you'll need a Plaid account. You can create one on [our w
 ## 2. Generate a link_token and add it to the sample app
 1. Clone the sample repository
 2. Curl [/link/token/create](https://plaid.com/docs/#create-link-token) to create a new link_token
-3. Copy and paste the link_token in [app/src/main/res/values/donottranslate.xml][link-token]
-
-```xml
-<resources>
-    <string name="plaid_public_key">TODO ADD YOUR LINK TOKEN HERE</string>
-</resources>
-```
+3. Copy and paste the link_token into the [kotlin][get-link-token-kotlin] or [java][get-link-token-java] `getLinkToken()` function.
 
 ## 3. Run the sample application
 1. 🚀
@@ -84,3 +78,5 @@ SOFTWARE.
 [plaid-dashboard-keys]: https://dashboard.plaid.com/team/keys
 [link-token]: https://github.com/plaid/plaid-link-android/blob/update-readme/app/src/main/res/values/donottranslate.xml
 [changelog]: https://github.com/plaid/plaid-link-android/releases
+[get-link-token-kotlin]: https://github.com/plaid/plaid-link-android/app/src/main/java/com/plaid/linksample/MainActivity.kt
+[get-link-token-java]: https://github.com/plaid/plaid-link-android/app/src/main/java/com/plaid/linksample/MainActivityJava.java

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,8 +32,8 @@
       android:theme="@style/AppTheme" />
 
     <meta-data
-      android:name="com.plaid.link.public_key"
-      android:value="@string/plaid_public_key" />
+      android:name="com.plaid.link.link_token"
+      android:value="@string/plaid_link_token" />
 
   </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,10 +31,6 @@
       android:label="@string/title_activity_main_java"
       android:theme="@style/AppTheme" />
 
-    <meta-data
-      android:name="com.plaid.link.link_token"
-      android:value="@string/plaid_link_token" />
-
   </application>
 
 </manifest>

--- a/app/src/main/java/com/plaid/linksample/MainActivity.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivity.kt
@@ -14,7 +14,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.plaid.link.Plaid
 import com.plaid.link.configuration.PlaidProduct
-import com.plaid.link.linkConfiguration
+import com.plaid.link.linkTokenConfiguration
 import com.plaid.link.openPlaidLink
 import com.plaid.link.result.PlaidLinkResultHandler
 
@@ -73,10 +73,8 @@ class MainActivity : AppCompatActivity() {
    */
   private fun openLink() {
     this@MainActivity.openPlaidLink(
-      linkConfiguration = linkConfiguration {
-        clientName = "Link demo"
-        products = listOf(PlaidProduct.TRANSACTIONS)
-        publicKey = getString(R.string.plaid_public_key)
+      linkTokenConfiguration = linkTokenConfiguration {
+        token = getString(R.string.plaid_link_token)
       }
     )
   }

--- a/app/src/main/java/com/plaid/linksample/MainActivity.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivity.kt
@@ -74,9 +74,20 @@ class MainActivity : AppCompatActivity() {
   private fun openLink() {
     this@MainActivity.openPlaidLink(
       linkTokenConfiguration = linkTokenConfiguration {
-        token = getString(R.string.plaid_link_token)
+        token = getLinkTokenFromServer()
       }
     )
+  }
+
+  /**
+   * In production, make an API request to your server to fetch
+   * a new link_token. Learn more at https://plaid.com/docs/#create-link-token.
+   *
+   * This is a dummy implementation. If you curl for a link_token, you can
+   * copy and paste the link_token value here.
+   */
+  private fun getLinkTokenFromServer(): String {
+    return "<GENERATED_LINK_TOKEN>"
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/com/plaid/linksample/MainActivityJava.java
+++ b/app/src/main/java/com/plaid/linksample/MainActivityJava.java
@@ -89,7 +89,7 @@ public class MainActivityJava extends AppCompatActivity {
     Plaid.openLink(
         this,
         new LinkTokenConfiguration.Builder()
-          .token(getString(R.string.plaid_link_token))
+          .token(getLinkTokenFromServer())
           .build()
           .toLinkConfiguration());
   }
@@ -121,5 +121,16 @@ public class MainActivityJava extends AppCompatActivity {
       default:
         return super.onOptionsItemSelected(item);
     }
+  }
+
+  /**
+   * In production, make an API request to your server to fetch
+   * a new link_token. Learn more at https://plaid.com/docs/#create-link-token.
+   *
+   * This is a dummy implementation. If you curl for a link_token, you can
+   * copy and paste the link_token value here.
+   */
+  private String getLinkTokenFromServer() {
+    return "<GENERATED_LINK_TOKEN>";
   }
 }

--- a/app/src/main/java/com/plaid/linksample/MainActivityJava.java
+++ b/app/src/main/java/com/plaid/linksample/MainActivityJava.java
@@ -17,7 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.plaid.link.Plaid;
-import com.plaid.link.configuration.LinkConfiguration;
+import com.plaid.link.configuration.LinkTokenConfiguration;
 import com.plaid.link.configuration.PlaidProduct;
 import com.plaid.link.result.PlaidLinkResultHandler;
 
@@ -88,11 +88,10 @@ public class MainActivityJava extends AppCompatActivity {
     products.add(PlaidProduct.TRANSACTIONS);
     Plaid.openLink(
         this,
-        new LinkConfiguration.Builder()
-            .clientName("Link demo")
-            .products(products)
-            .publicKey(getString(R.string.plaid_public_key))
-            .build());
+        new LinkTokenConfiguration.Builder()
+          .token(getString(R.string.plaid_link_token))
+          .build()
+          .toLinkConfiguration());
   }
 
   @Override

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2020 Plaid Technologies, Inc. <support@plaid.com>
-  -->
-
-<resources>
-  <string name="plaid_link_token">TODO ADD YOUR LINK TOKEN HERE</string>
-</resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -3,5 +3,5 @@
   -->
 
 <resources>
-  <string name="plaid_public_key">TODO ADD YOUR KEY HERE</string>
+  <string name="plaid_link_token">TODO ADD YOUR LINK TOKEN HERE</string>
 </resources>


### PR DESCRIPTION
Updated the Readme and examples to use the link token instead of the public_key since this is the preferred integration path now. I tested and was able to get the normal path to work.

I tested with an OAuth institution though, and wasn't able to complete the flow for some reason... I'm guessing this might be because of how my simulator was set up? 
```
memtrack: Couldn't load memtrack module
07-19 18:28:16.069  2099  2137 W android.os.Debug: failed to get memory consumption info: -1
07-19 18:28:21.006  2015  2015 E netmgr  : Failed to open QEMU pipe 'qemud:network': Invalid argument
```