### PR TITLE
Update to SDK V3.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation "com.plaid.link:sdk-core:3.4.0"
 
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "androidx.core:core-ktx:1.3.2"
     implementation "androidx.constraintlayout:constraintlayout:2.0.2"
     implementation "com.google.android.material:material:1.2.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation "com.plaid.link:sdk-core:3.3.1"
+    implementation "com.plaid.link:sdk-core:3.4.0"
 
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.kotlin_version = '1.5.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -22,7 +22,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
- Update to latest Link SDK
- Update Gradle and Kotlin
- Replace JCenter with MavenCentral