### PR TITLE
ANDROID: Fix strange title crash

### DIFF
--- a/app/src/main/java/com/plaid/linksample/MainActivityResultContractActivity.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivityResultContractActivity.kt
@@ -4,8 +4,10 @@
 
 package com.plaid.linksample
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.AttributeSet
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -61,7 +63,6 @@ class MainActivityResultContractActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
-    setActionBar(findViewById(R.id.toolbar))
     result = findViewById(R.id.result)
     tokenResult = findViewById(R.id.public_token_result)
 
@@ -70,6 +71,12 @@ class MainActivityResultContractActivity : AppCompatActivity() {
       setOptionalEventListener()
       openLink()
     }
+  }
+
+  override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
+    val view = super.onCreateView(name, context, attrs)
+    setActionBar(findViewById(R.id.toolbar))
+    return view
   }
 
   /**


### PR DESCRIPTION
Getting a strange NPE:
NullPointerException
Attempt to invoke virtual method 'java.lang.CharSequence android.widget.Toolbar.getTitle()' on a null object reference

Hopefully waiting until the view is created mitigates this