### PR TITLE
Add exported tags

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.plaid.linksample"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     android:usesCleartextTraffic="true">   <!-- `usesCleartextTraffic` is only to allow http traffic to localhost. Do not use this for production apps.-->
     <activity
       android:name=".MainActivity"
+      android:exported="true"
       android:label="@string/title_activity_main"
       android:theme="@style/AppTheme">
       <intent-filter>
@@ -27,16 +28,19 @@
 
     <activity
       android:name=".MainActivityJava"
+      android:exported="true"
       android:label="@string/title_activity_main_java"
       android:theme="@style/AppTheme" />
 
     <activity
       android:name=".MainActivityResultContractActivity"
+      android:exported="true"
       android:label="@string/title_activity_main_activity_result_contract"
       android:theme="@style/AppTheme" />
 
     <activity
       android:name=".MainActivityResultContractActivityJava"
+      android:exported="true"
       android:label="@string/title_activity_main_activity_result_contract_java"
       android:theme="@style/AppTheme" />
 


### PR DESCRIPTION
Android 12 requires explicit exported tags on all Activities. Updating our sample to support this!