### PR TITLE
Make OpenPlaidLink ActivityResultContract the default example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OR
 # Features
 - How to integrate the Plaid Link sdk: `build.gradle` files, `link_token` configuration, `Plaid` initialization
 - Kotlin and Java sample Activity that show how to start Link and receive a result
-- Use of `PlaidLinkResultHandler` for easy handling of Link results
+- Use of `OpenPlaidLink` `ActivityResultContract` for easy handling of Link results
 - _Optional_ use of `LinkEventListener` to get events from Link
 
 Have a look at our [main documentation][link-android-docs] for all Plaid Link SDK features.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,13 +33,13 @@
       android:theme="@style/AppTheme" />
 
     <activity
-      android:name=".MainActivityResultContractActivity"
+      android:name=".MainActivityStartActivityForResult"
       android:exported="true"
       android:label="@string/title_activity_main_activity_result_contract"
       android:theme="@style/AppTheme" />
 
     <activity
-      android:name=".MainActivityResultContractActivityJava"
+      android:name=".MainActivityStartActivityForResultJava"
       android:exported="true"
       android:label="@string/title_activity_main_activity_result_contract_java"
       android:theme="@style/AppTheme" />

--- a/app/src/main/java/com/plaid/linksample/MainActivity.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivity.kt
@@ -94,7 +94,7 @@ class MainActivity : AppCompatActivity() {
         true
       }
       R.id.show_activity_result_java -> {
-//        val intent = Intent(this@MainActivity, MainActivityResultContractActivityJava::class.java)
+        val intent = Intent(this@MainActivity, MainActivityStartActivityForResultJava::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         startActivity(intent)
         true

--- a/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResult.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResult.kt
@@ -4,10 +4,8 @@
 
 package com.plaid.linksample
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.AttributeSet
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -15,49 +13,38 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.plaid.link.OpenPlaidLink
 import com.plaid.link.Plaid
-import com.plaid.link.PlaidActivityResultContract
 import com.plaid.link.configuration.LinkTokenConfiguration
-import com.plaid.link.result.LinkExit
-import com.plaid.link.result.LinkResult
-import com.plaid.link.result.LinkSuccess
+import com.plaid.link.result.LinkResultHandler
 import com.plaid.linksample.network.LinkTokenRequester
 
-class MainActivityResultContractActivity : AppCompatActivity() {
+class MainActivityStartActivityForResult : AppCompatActivity() {
 
   private lateinit var result: TextView
   private lateinit var tokenResult: TextView
 
-  @OptIn(PlaidActivityResultContract::class)
-  // Experimental API using ActivityResultContract for androidx.fragment:1.3.0+
-  private val openPlaidLink = this.registerForActivityResult(
-    OpenPlaidLink()
-  ) { linkResult: LinkResult ->
-    when (linkResult) {
-      is LinkSuccess -> {
-        tokenResult.text = getString(R.string.public_token_result, linkResult.publicToken)
+  private val myPlaidResultHandler by lazy {
+    LinkResultHandler(
+      onSuccess = {
+        tokenResult.text = getString(R.string.public_token_result, it.publicToken)
         result.text = getString(R.string.content_success)
-      }
-      is LinkExit -> {
+      },
+      onExit = {
         tokenResult.text = ""
-        if (linkResult.error != null) {
+        if (it.error != null) {
           result.text = getString(
             R.string.content_exit,
-            linkResult.error?.displayMessage,
-            linkResult.error?.errorCode
+            it.error?.displayMessage,
+            it.error?.errorCode
           )
         } else {
           result.text = getString(
             R.string.content_cancel,
-            linkResult.metadata.status?.jsonValue ?: "unknown"
+            it.metadata.status?.jsonValue ?: "unknown"
           )
         }
       }
-      else -> {
-        throw RuntimeException("Got unexpected result:$linkResult")
-      }
-    }
+    )
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,12 +58,6 @@ class MainActivityResultContractActivity : AppCompatActivity() {
       setOptionalEventListener()
       openLink()
     }
-  }
-
-  override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
-    val view = super.onCreateView(name, context, attrs)
-    setActionBar(findViewById(R.id.toolbar))
-    return view
   }
 
   /**
@@ -98,9 +79,10 @@ class MainActivityResultContractActivity : AppCompatActivity() {
     val tokenConfiguration = LinkTokenConfiguration.Builder()
       .token(linkToken)
       .build()
-
-    // Experimental API using ActivityResultContract for androidx.fragment:1.3.0+
-    openPlaidLink.launch(tokenConfiguration)
+    Plaid.create(
+      this.application,
+      tokenConfiguration
+    ).open(this)
   }
 
   private fun onLinkTokenError(error: Throwable) {
@@ -111,19 +93,11 @@ class MainActivityResultContractActivity : AppCompatActivity() {
     Toast.makeText(this, error.message, Toast.LENGTH_SHORT).show()
   }
 
-  override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-    menuInflater.inflate(R.menu.menu_java, menu)
-    return true
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, intent)
+    if (!myPlaidResultHandler.onActivityResult(requestCode, resultCode, data)) {
+      Log.i(MainActivity::class.java.simpleName, "Not handled")
+    }
   }
 
-  override fun onOptionsItemSelected(item: MenuItem): Boolean =
-    when (item.itemId) {
-      R.id.show_kotlin -> {
-        val intent = Intent(this@MainActivityResultContractActivity, MainActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        startActivity(intent)
-        true
-      }
-      else -> super.onOptionsItemSelected(item)
-    }
 }

--- a/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResult.kt
+++ b/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResult.kt
@@ -18,6 +18,10 @@ import com.plaid.link.configuration.LinkTokenConfiguration
 import com.plaid.link.result.LinkResultHandler
 import com.plaid.linksample.network.LinkTokenRequester
 
+/**
+ * Old approach to opening Plaid Link, we recommend switching over to the
+ * OpenPlaidLink ActivityResultContract instead.
+ */
 class MainActivityStartActivityForResult : AppCompatActivity() {
 
   private lateinit var result: TextView

--- a/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResultJava.java
+++ b/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResultJava.java
@@ -22,7 +22,10 @@ import com.plaid.link.result.LinkResultHandler;
 import com.plaid.linksample.network.LinkTokenRequester;
 import kotlin.Unit;
 
-
+/**
+ * Old approach to opening Plaid Link, we recommend switching over to the
+ * OpenPlaidLink ActivityResultContract instead.
+ */
 public class MainActivityStartActivityForResultJava extends AppCompatActivity {
 
   private TextView result;

--- a/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResultJava.java
+++ b/app/src/main/java/com/plaid/linksample/MainActivityStartActivityForResultJava.java
@@ -13,56 +13,47 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
-import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.plaid.link.OpenPlaidLink;
 import com.plaid.link.Plaid;
 import com.plaid.link.configuration.LinkTokenConfiguration;
-import com.plaid.link.result.LinkExit;
-import com.plaid.link.result.LinkSuccess;
+import com.plaid.link.result.LinkResultHandler;
 import com.plaid.linksample.network.LinkTokenRequester;
-
 import kotlin.Unit;
 
 
-public class MainActivityResultContractActivityJava extends AppCompatActivity {
+public class MainActivityStartActivityForResultJava extends AppCompatActivity {
 
   private TextView result;
   private TextView tokenResult;
 
-  // Experimental API using ActivityResultContract for androidx.fragment:1.3.0+
-  private ActivityResultLauncher<LinkTokenConfiguration> openPlaidLink =
-      this.registerForActivityResult(
-          new OpenPlaidLink(),
-          linkResult -> {
-            if (linkResult instanceof LinkSuccess) {
-              String tokenString = ((LinkSuccess) linkResult).getPublicToken();
-              tokenResult.setText(getString(
-                  R.string.public_token_result,
-                  tokenString));
-              result.setText(getString(
-                  R.string.content_success));
-            } else if (linkResult instanceof LinkExit) {
-              LinkExit linkExit = (LinkExit) linkResult;
-              tokenResult.setText("");
-              if (linkExit.getError() != null) {
-                result.setText(getString(
-                    R.string.content_exit,
-                    linkExit.getError().getDisplayMessage(),
-                    linkExit.getError().getErrorCode()));
-              } else {
-                result.setText(getString(
-                    R.string.content_cancel,
-                    linkExit.getMetadata().getStatus() != null ? linkExit.getMetadata()
-                        .getStatus()
-                        .getJsonValue() : "unknown"));
-              }
-            } else {
-              throw new RuntimeException("Got unexpected result:" + result);
-            }
-          });
+  private LinkResultHandler myPlaidResultHandler = new LinkResultHandler(
+      linkSuccess -> {
+        tokenResult.setText(getString(
+            R.string.public_token_result,
+            linkSuccess.getPublicToken()));
+        result.setText(getString(
+            R.string.content_success));
+        return Unit.INSTANCE;
+      },
+      linkExit -> {
+        tokenResult.setText("");
+        if (linkExit.getError() != null) {
+          result.setText(getString(
+              R.string.content_exit,
+              linkExit.getError().getDisplayMessage(),
+              linkExit.getError().getErrorCode()));
+        } else {
+          result.setText(getString(
+              R.string.content_cancel,
+              linkExit.getMetadata().getStatus() != null ? linkExit.getMetadata()
+                  .getStatus()
+                  .getJsonValue() : "unknown"));
+        }
+        return Unit.INSTANCE;
+      }
+  );
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -98,10 +89,12 @@ public class MainActivityResultContractActivityJava extends AppCompatActivity {
   }
 
   private void onLinkTokenSuccess(String token) {
-    // Experimental API using ActivityResultContract for androidx.fragment:1.3.0+
-    openPlaidLink.launch(new LinkTokenConfiguration.Builder()
-        .token(token)
-        .build());
+    Plaid.create(
+        getApplication(),
+        new LinkTokenConfiguration.Builder()
+            .token(token)
+            .build())
+        .open(this);
   }
 
   private void onLinkTokenError(Throwable error) {
@@ -113,6 +106,14 @@ public class MainActivityResultContractActivityJava extends AppCompatActivity {
       return;
     }
     Toast.makeText(this, error.getMessage(), Toast.LENGTH_SHORT).show();
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+    if (!myPlaidResultHandler.onActivityResult(requestCode, resultCode, data)) {
+      Log.i(MainActivityJava.class.getSimpleName(), "Not handled");
+    }
   }
 
   @Override

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -9,11 +9,11 @@
     android:title="@string/open_java" />
 
   <item
-    android:id="@+id/show_activity_result_contract"
-    android:title="@string/open_activity_result_contract" />
+    android:id="@+id/show_activity_result"
+    android:title="@string/open_activity_result" />
 
 
   <item
-    android:id="@+id/show_activity_result_contract_java"
-    android:title="@string/open_activity_result_contract_java" />
+    android:id="@+id/show_activity_result_java"
+    android:title="@string/open_activity_result_java" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,8 +36,8 @@
   <string name="open_java">Open Java demo</string>
   <string name="open_kotlin">Open Kotlin demo</string>
   <string name="open_link">Open Link</string>
-  <string name="open_activity_result_contract">Open ActivityResultContract demo (Kotlin)</string>
-  <string name="title_activity_main_activity_result_contract">Link demo (ActivityResultContract)</string>
-  <string name="open_activity_result_contract_java">Open Activity Result Contract demo (Java)</string>
-  <string name="title_activity_main_activity_result_contract_java">Link demo (ActivityResultContract Java)</string>
+  <string name="open_activity_result">Open startActivityForResult demo (Kotlin)</string>
+  <string name="title_activity_main_activity_result_contract">Link demo (startActivityForResult)</string>
+  <string name="open_activity_result_java">Open startActivityForResult demo (Java)</string>
+  <string name="title_activity_main_activity_result_contract_java">Link demo (startActivityForResult Java)</string>
 </resources>


### PR DESCRIPTION
Since the recommended way to open Link is through the `OpenPlaidLink` `ActivityResultContract`, let's switch the default examples around:

- default is now `ActivityResultContract`
- fallback is manually starting the Activity for result