### PR TITLE
Link android SDK v3.8.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation "com.plaid.link:sdk-core:3.7.1"
+    implementation "com.plaid.link:sdk-core:3.8.0"
 
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.core:core-ktx:1.3.2"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,13 +24,14 @@ android {
 dependencies {
     implementation "com.plaid.link:sdk-core:3.8.0"
 
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "androidx.core:core-ktx:1.3.2"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.2"
-    implementation "com.google.android.material:material:1.2.1"
+    implementation "androidx.appcompat:appcompat:1.4.1"
+    implementation "androidx.core:core-ktx:1.7.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.3"
+    implementation "com.google.android.material:material:1.5.0"
+    implementation "io.reactivex.rxjava3:rxandroid:3.0.0"
+    implementation 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
 
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.9.0"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:2.9.0"
     implementation "com.google.code.gson:gson:2.8.6"
 }

--- a/app/src/main/java/com/plaid/linksample/network/LinkSampleApi.kt
+++ b/app/src/main/java/com/plaid/linksample/network/LinkSampleApi.kt
@@ -1,7 +1,7 @@
 package com.plaid.linksample.network
 
 import com.google.gson.annotations.SerializedName
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Single
 import retrofit2.http.POST
 
 /**

--- a/app/src/main/java/com/plaid/linksample/network/LinkTokenRequester.kt
+++ b/app/src/main/java/com/plaid/linksample/network/LinkTokenRequester.kt
@@ -1,11 +1,10 @@
 package com.plaid.linksample.network
 
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.schedulers.Schedulers
-import io.reactivex.Single
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.schedulers.Schedulers
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 
 object LinkTokenRequester {
@@ -16,7 +15,7 @@ object LinkTokenRequester {
     .baseUrl(baseUrl)
     .client(OkHttpClient.Builder().build())
     .addConverterFactory(GsonConverterFactory.create())
-    .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
     .build()
 
   private val api = retrofit.create(LinkSampleApi::class.java)


### PR DESCRIPTION
Updates to our latest SDK version + updates `LinkTokenRequester` to use `RxJava3`.

The latter was needed because our example was transitively using `RxJava2` through our Link SDK, but since we remove those dependencies compilation broke. And it didn't feel right to explicitly add `RxJava2` as a dependency after being deprecated for so long.