### PR TITLE
Release Android 3.11.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation "com.plaid.link:sdk-core:3.10.2"
+    implementation "com.plaid.link:sdk-core:3.11.0"
 
     implementation "androidx.appcompat:appcompat:1.4.1"
     implementation "androidx.core:core-ktx:1.7.0"


### PR DESCRIPTION
Bump this sample app up to version 3.11.0 which includes support for opening Link in an out of process web view.