### PR TITLE
Update Example App To Use Improved Loading API

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,10 +30,19 @@
     android:text="@string/landing_text" />
 
   <com.google.android.material.button.MaterialButton
+    android:id="@+id/prepare_link"
+    style="@style/PlaidButton"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/space_2x"
+    android:text="@string/prepare_link" />
+
+  <com.google.android.material.button.MaterialButton
     android:id="@+id/open_link"
     style="@style/PlaidButton"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:enabled="false"
     android:text="@string/open_link" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main_fragment.xml
+++ b/app/src/main/res/layout/activity_main_fragment.xml
@@ -42,11 +42,20 @@
     android:text="@string/landing_text" />
 
   <com.google.android.material.button.MaterialButton
+    android:id="@+id/prepare_link"
+    style="@style/PlaidButton"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/space_2x"
+    android:text="@string/prepare_link" />
+
+  <com.google.android.material.button.MaterialButton
     android:id="@+id/open_link"
     style="@style/PlaidButton"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/space_2x"
+    android:enabled="false"
     android:text="@string/open_link" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
 </string>
   <string name="open_java">Open Java demo</string>
   <string name="open_kotlin">Open Kotlin demo</string>
+  <string name="prepare_link">Prepare Link</string>
   <string name="open_link">Open Link</string>
   <string name="open_activity_result">Open startActivityForResult demo (Kotlin)</string>
   <string name="title_activity_main_activity_result_contract">Link demo (startActivityForResult)</string>


### PR DESCRIPTION
While no breaking changes were introduced in 4.2.0, this release did introduce improved loading that can be unlocked when a `PlaidHandler` is created with a `LinkTokenConfiguration` before Link is opened. This PR updates the example app to be setup to support this by:
- adding a Prepare Link button which creates a `PlaidHandler` with a `LinkTokenConfiguration`, before link can be opened.
- swapping the `OpenPlaidLink` `ActivityResultContract` out for the newer improved `FastOpenPlaidLink` `ActivityResultContract`