### PR TITLE
Release 5.3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    implementation "com.plaid.link:sdk-core:5.3.3"
+    implementation "com.plaid.link:sdk-core:5.3.4"
 
     implementation "androidx.appcompat:appcompat:1.6.1"
     implementation "androidx.core:core-ktx:1.12.0"


### PR DESCRIPTION
Bump sample app to use new release [5.3.4](https://github.com/plaid/plaid-link-android/releases/tag/v5.3.4).