### PR TITLE
Update Link Token docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If your integration is using public key authentication, it's essential to migrat
 #### 2. Open Options Configuration
 **BREAKING**: Removed `extraParams(extraParams: Map<String, String>)` setter method from  `LinkTokenConfiguration#Builder`.
 
-If your integration relies on `extraParams`, you must now configure these parameters while creating your [Link Tokens](https://plaid.com/docs/api/tokens/). Update your implementation accordingly.
+If your integration relies on `extraParams`, you must now configure these parameters while creating your [Link Tokens](https://plaid.com/docs/api/link/). Update your implementation accordingly.
 
 #### 3. Upgrade to Kotlin 1.8
 The Link Android SDK version of Kotlin has been upgraded to 1.8 and may need to be updated in your project.


### PR DESCRIPTION
The README pointed at \`https://plaid.com/docs/api/tokens/\`, which 404s. Plaid migrated the Link Token reference under \`https://plaid.com/docs/api/link/\` (verified 200).

## Test plan
- [ ] Click the "Link Tokens" link in the rendered README and confirm it loads the Link API reference page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c